### PR TITLE
Fix_Topapage_view

### DIFF
--- a/app/views/toppage/index.html.haml
+++ b/app/views/toppage/index.html.haml
@@ -7,11 +7,13 @@
         .info_name
           こんにちは、#{current_user.nickname}さん
     %ul
-      = link_to "マイページ"
       - if user_signed_in?
-        = link_to "ログアウト", destroy_user_session_path, method: :delete 
+        = link_to "新規投稿"
+        = link_to "マイページ"
+        = link_to "ログアウト", destroy_user_session_path, method: :delete
       - else
-        = link_to "新規登録", new_user_session_path
+        = link_to "新規登録", new_user_registration_path
+        = link_to "ログイン", new_user_session_path
         
   .main
     .select


### PR DESCRIPTION
# what
Topページのヘッダーを修正
※確認は不要のためマージしてしまいます。

# why
ログイン前後のヘッダーのパスや記載内容が不足していたため