### PR TITLE
Fix signup error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@
 
 ## ER 図
 
-<img width="567" alt="ER?" src="https://user-images.githubusercontent.com/50095754/90325995-aba8c980-dfbd-11ea-97c1-4bfb562016d3.png">
+<img width="567" alt="ER?" src="https://user-images.githubusercontent.com/50095754/93402025-9544a500-f8be-11ea-8033-aab29549e886.png">

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
     added_attrs = [ :nickname,
       :password,
       :password_confirmation,
-      :programing_language_id ,
-      :learning_method_id
+      :learning_method_id,
+      language_ids: []
     ]
     devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
     devise_parameter_sanitizer.permit(:sign_in, keys: added_attrs)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,7 +7,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # GET /resource/sign_up
   def new
     @user = User.new
-    @language = @user.build_language
     @learning_method = @user.build_learning_method
   end
 

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,3 +1,4 @@
 class Language < ApplicationRecord
-  has_many :users
+  has_many :user_languages, dependent: :destroy
+  has_many :users, through: :user_languages
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,4 +1,4 @@
 class Language < ApplicationRecord
-  has_many :user_languages, dependent: :destroy
+  has_many :user_languages
   has_many :users, through: :user_languages
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   has_many :posts
-  belongs_to :language
+  has_many :user_languages, dependent: :destroy
+  has_many :languages, through: :user_languages
   belongs_to :learning_method
   devise :database_authenticatable, :recoverable, :rememberable,:registerable, :authentication_keys => [:nickname]
-  accepts_nested_attributes_for :language,:learning_method
+  accepts_nested_attributes_for :learning_method
 end

--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -1,0 +1,4 @@
+class UserLanguage < ApplicationRecord
+  belongs_to :user
+  belongs_to :language
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -22,7 +22,7 @@
           .field
             = f.label :programing_language, class: "field_name"
             .field_checkbox
-              = f.collection_check_boxes :language_id, Language.all, :id, :programing_language, :include_blank => true
+              = f.collection_check_boxes(:language_ids, Language.all, :id, :programing_language, include_hidden: false)
           .field
             = f.label :method, class: "field_name"
             .field_selectbox

--- a/db/migrate/20200915220247_change_column_to_users.rb
+++ b/db/migrate/20200915220247_change_column_to_users.rb
@@ -1,0 +1,7 @@
+class ChangeColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :users, :languages
+    remove_index :users, :language_id
+    remove_reference :users, :language
+  end
+end

--- a/db/migrate/20200915222631_create_user_languages.rb
+++ b/db/migrate/20200915222631_create_user_languages.rb
@@ -1,0 +1,10 @@
+class CreateUserLanguages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_languages do |t|
+      t.references :user, foreign_key: true
+      t.references :language, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_192747) do
+ActiveRecord::Schema.define(version: 2020_09_15_222631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,18 +58,25 @@ ActiveRecord::Schema.define(version: 2020_08_28_192747) do
     t.string "business_form"
   end
 
+  create_table "user_languages", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "language_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id"], name: "index_user_languages_on_language_id"
+    t.index ["user_id"], name: "index_user_languages_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "image"
     t.string "encrypted_password", default: "", null: false
-    t.bigint "language_id"
     t.bigint "learning_method_id"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["language_id"], name: "index_users_on_language_id"
     t.index ["learning_method_id"], name: "index_users_on_learning_method_id"
   end
 
@@ -78,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_192747) do
   add_foreign_key "posts", "places"
   add_foreign_key "posts", "styles"
   add_foreign_key "posts", "users"
-  add_foreign_key "users", "languages"
+  add_foreign_key "user_languages", "languages"
+  add_foreign_key "user_languages", "users"
   add_foreign_key "users", "learning_methods"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,8 +26,25 @@ User.create!(
   nickname: 'test-user',
   password: 'password',
   password_confirmation: 'password',
-  language_id: '4',
   learning_method_id:'1'
+)
+
+#テストユーザーの中間テーブルを作成
+UserLanguage.create!(
+  user_id: '1',
+  language_id: '1'
+)
+UserLanguage.create!(
+  user_id: '1',
+  language_id: '2'
+)
+UserLanguage.create!(
+  user_id: '1',
+  language_id: '3'
+)
+UserLanguage.create!(
+  user_id: '1',
+  language_id: '4'
 )
 
 # 質問内容を追加


### PR DESCRIPTION
## what
ユーザー登録のエラーを修正
登録時に複数の学習言語を選択できるように修正
- userとlanguageのアソシエーションの設定を削除
- userとlanguageの中間テーブル(user_language)を追加
- シードデータ を修正　※中間テーブルを同時に作成する方法がわからないので力づくです

## why
ユーザー登録時に複数の言語を登録できるようにする為